### PR TITLE
Add darwin support

### DIFF
--- a/logger_syslog.go
+++ b/logger_syslog.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +build linux
+// +build linux darwin
 
 package logger
 


### PR DESCRIPTION
`log/syslog` module has been supported `darwin` on current Go stable version (1.6).
Not ignored `darwin`.
https://github.com/golang/go/blob/master/src/log/syslog/syslog.go#L5

If fix `+build linux darwin` for 
https://github.com/google/logger/blob/master/logger_linux.go#L14
,but can not build by the build file structure of Go.

So, I create a new `logger_darwin.go`.
If it is not the correct way, please point out.

In addition, If need a sign-off of google to special license(CLA?), I willing to sign.
