### PR TITLE
Added warning writer for warnings level log messages

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -75,22 +75,27 @@ func init() {
 // If the logFile passed in also satisfies io.Closer, logFile.Close will be called
 // when closing the logger.
 func Init(name string, verbose, systemLog bool, logFile io.Writer) *Logger {
-	var il, el io.Writer
+	var il, wl, el io.Writer
 	if systemLog {
 		var err error
-		il, el, err = setup(name)
+		il, wl, el, err = setup(name)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
 	iLogs := []io.Writer{logFile}
+	wLogs := []io.Writer{logFile}
 	eLogs := []io.Writer{logFile, os.Stderr}
 	if verbose {
 		iLogs = append(iLogs, os.Stdout)
+		wLogs = append(wLogs, os.Stdout)
 	}
 	if il != nil {
 		iLogs = append(iLogs, il)
+	}
+	if wl != nil {
+		wLogs = append(iLogs, wl)
 	}
 	if el != nil {
 		eLogs = append(eLogs, el)
@@ -98,11 +103,11 @@ func Init(name string, verbose, systemLog bool, logFile io.Writer) *Logger {
 
 	l := Logger{
 		infoLog:    log.New(io.MultiWriter(iLogs...), tagInfo, flags),
-		warningLog: log.New(io.MultiWriter(iLogs...), tagWarning, flags),
+		warningLog: log.New(io.MultiWriter(wLogs...), tagWarning, flags),
 		errorLog:   log.New(io.MultiWriter(eLogs...), tagError, flags),
 		fatalLog:   log.New(io.MultiWriter(eLogs...), tagFatal, flags),
 	}
-	for _, w := range []io.Writer{logFile, il, el} {
+	for _, w := range []io.Writer{logFile, il, wl, el} {
 		if c, ok := w.(io.Closer); ok && c != nil {
 			l.closers = append(l.closers, c)
 		}

--- a/logger.go
+++ b/logger.go
@@ -95,7 +95,7 @@ func Init(name string, verbose, systemLog bool, logFile io.Writer) *Logger {
 		iLogs = append(iLogs, il)
 	}
 	if wl != nil {
-		wLogs = append(iLogs, wl)
+		wLogs = append(wLogs, wl)
 	}
 	if el != nil {
 		eLogs = append(eLogs, el)

--- a/logger_syslog.go
+++ b/logger_syslog.go
@@ -19,14 +19,18 @@ import (
 	"log/syslog"
 )
 
-func setup(src string) (*syslog.Writer, *syslog.Writer, error) {
+func setup(src string) (*syslog.Writer, *syslog.Writer, *syslog.Writer, error) {
 	il, err := syslog.New(syslog.LOG_NOTICE, src)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+	wl, err := syslog.New(syslog.LOG_WARNING, src)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	el, err := syslog.New(syslog.LOG_ERR, src)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return il, el, nil
+	return il, wl, el, nil
 }


### PR DESCRIPTION
Currently warning level logs share the info log writer. In windows event viewer this shows warnings as information level events instead of warnings making it hard to filter for warnings if needed. I added an extra writer that uses syslog's warning level and event logs warning level so warning logs now show up as warnings in the logs. 