### PR TITLE
Add SetFlags to customize the format for the messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,24 @@ logger.Info("This is the same as using loggerOne")
 
 ```
 
+## Custom Format ##
 
+| Code                                 | Example                                                  |
+|--------------------------------------|----------------------------------------------------------|
+| `logger.SetFlags(log.Ldate)`         | ERROR: 2018/11/11 Error running Foobar: message          |
+| `logger.SetFlags(log.Ltime)`         | ERROR: 09:42:45 Error running Foobar: message            |
+| `logger.SetFlags(log.Lmicroseconds)` | ERROR: 09:42:50.776015 Error running Foobar: message     |
+| `logger.SetFlags(log.Llongfile)`     | ERROR: /src/main.go:31: Error running Foobar: message    |
+| `logger.SetFlags(log.Lshortfile)`    | ERROR: main.go:31: Error running Foobar: message         |
+| `logger.SetFlags(log.LUTC)`          | ERROR: Error running Foobar: message                     |
+| `logger.SetFlags(log.LstdFlags)`     | ERROR: 2018/11/11 09:43:12 Error running Foobar: message |
+
+```go
+func main() {
+    lf, err := os.OpenFile(logPath, …, 0660)
+    defer logger.Init("foo", *verbose, true, lf).Close()
+    logger.SetFlags(log.LstdFlags)
+}
+```
+
+More info: https://golang.org/pkg/log/#pkg-constants

--- a/logger.go
+++ b/logger.go
@@ -270,6 +270,14 @@ func (l *Logger) Fatalf(format string, v ...interface{}) {
 	os.Exit(1)
 }
 
+// SetFlags sets the output flags for the logger.
+func SetFlags(flag int) {
+	defaultLogger.infoLog.SetFlags(flag)
+	defaultLogger.warningLog.SetFlags(flag)
+	defaultLogger.errorLog.SetFlags(flag)
+	defaultLogger.fatalLog.SetFlags(flag)
+}
+
 // Info uses the default logger and logs with the Info severity.
 // Arguments are handled in the manner of fmt.Print.
 func Info(v ...interface{}) {


### PR DESCRIPTION
These flags define which text to prefix to each log entry generated by the Logger.

Bits are or'ed together to control what's printed. There is no control over the order they appear (the order listed here) or the format they present (as described in the comments). The prefix is followed by a colon only when `Llongfile` or `Lshortfile` is specified. For example:

```go
log.SetFlags(LstdFlags)
// -> 2009/01/23 01:23:23 message

log. SetFlags(Ldate | Ltime)
// -> 2009/01/23 01:23:23 message

log.SetFlags(Ldate | Ltime | Lmicroseconds | Llongfile)
// -> 2009/01/23 01:23:23.123123 /a/b/c/d.go:23: message
```

More info: https://golang.org/pkg/log/#pkg-constants