### PR TITLE
Default syslogging to the LOG_USER facility.

### DIFF
--- a/logger_syslog.go
+++ b/logger_syslog.go
@@ -20,15 +20,16 @@ import (
 )
 
 func setup(src string) (*syslog.Writer, *syslog.Writer, *syslog.Writer, error) {
-	il, err := syslog.New(syslog.LOG_NOTICE, src)
+	const facility = syslog.LOG_USER
+	il, err := syslog.New(facility|syslog.LOG_NOTICE, src)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	wl, err := syslog.New(syslog.LOG_WARNING, src)
+	wl, err := syslog.New(facility|syslog.LOG_WARNING, src)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	el, err := syslog.New(syslog.LOG_ERR, src)
+	el, err := syslog.New(facility|syslog.LOG_ERR, src)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
Right now logger does not specify any facility. Unfortunately that means
that all syslogging then defaults to LOG_KERN, which is reserved for
kernel messages. That is confusing. Putting everything at LOG_USER makes
more sense.