### PR TITLE
Do not crash if syslog cannot be initialized

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -76,12 +76,9 @@ func init() {
 // when closing the logger.
 func Init(name string, verbose, systemLog bool, logFile io.Writer) *Logger {
 	var il, wl, el io.Writer
+	var syslogErr error
 	if systemLog {
-		var err error
-		il, wl, el, err = setup(name)
-		if err != nil {
-			log.Fatal(err)
-		}
+		il, wl, el, syslogErr = setup(name)
 	}
 
 	iLogs := []io.Writer{logFile}
@@ -120,6 +117,10 @@ func Init(name string, verbose, systemLog bool, logFile io.Writer) *Logger {
 	defer logLock.Unlock()
 	if !defaultLogger.initialized {
 		defaultLogger = &l
+	}
+
+	if syslogErr != nil {
+		Error(syslogErr)
 	}
 
 	return &l


### PR DESCRIPTION
There can be many reasons why /dev/log is not working, most notably
because syslog is down or crashing. Be more gentle to the program -
which might be a system service - by not hard failing the request
and instead just logging it normally as an error.