### PR TITLE
Fix nil interface != nil issue

### DIFF
--- a/logger_syslog.go
+++ b/logger_syslog.go
@@ -16,10 +16,11 @@ limitations under the License.
 package logger
 
 import (
+	"io"
 	"log/syslog"
 )
 
-func setup(src string) (*syslog.Writer, *syslog.Writer, *syslog.Writer, error) {
+func setup(src string) (io.Writer, io.Writer, io.Writer, error) {
 	const facility = syslog.LOG_USER
 	il, err := syslog.New(facility|syslog.LOG_NOTICE, src)
 	if err != nil {

--- a/logger_windows.go
+++ b/logger_windows.go
@@ -15,6 +15,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"golang.org/x/sys/windows"
@@ -44,7 +45,7 @@ func (w *writer) Close() error {
 	return w.el.Close()
 }
 
-func newW(pri severity, src string) (*writer, error) {
+func newW(pri severity, src string) (io.WriteCloser, error) {
 	// Continue if we receive "registry key already exists" or if we get
 	// ERROR_ACCESS_DENIED so that we can log without administrative permissions
 	// for pre-existing eventlog sources.
@@ -64,7 +65,7 @@ func newW(pri severity, src string) (*writer, error) {
 	}, nil
 }
 
-func setup(src string) (*writer, *writer, *writer, error) {
+func setup(src string) (io.WriteCloser, io.WriteCloser, io.WriteCloser, error) {
 	infoL, err := newW(sInfo, src)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
TL;DR: https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7

When `Init()` calls `setup()` and `setup()` fails, it would return a `nil` value of the type `*syslog.Writer`. Storing this inside an `io.Writer` interface type variable `il`, `wl`, or `el` inside `Init()` means that those variables will not be `nil` (because they are a valid `nil` value of the `io.Writer` interface). Thus the checks `if il != nil` etc. will always be true and the `nil` value `syslog.Writer` pointer will always be added to the `iLogs`, `wLogs`, `eLogs` lists. Because we're in a case where `setup()` returned an error, we'll attempt to log the error later on using the `io.MultiWriter(eLogs...)` which contains one `nil` value writer. This means the `syslog.(*Writer).Write()` call will fail with segmentation violation and lead to the program crashing.

With this commit, we change the interface of `setup()` to return `io.Writer` interface values directly which can be safely compared against `nil` and  thus the `nil` value writers are never added to the `io.MultiWriter`s.