### PR TITLE
Add a stub setup function for !unix && !windows builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/google/logger
 
-go 1.12
+go 1.18
 
 require golang.org/x/sys v0.1.0

--- a/logger_other.go
+++ b/logger_other.go
@@ -1,0 +1,12 @@
+//go:build !unix && !windows
+
+package logger
+
+import (
+	"errors"
+	"io"
+)
+
+func setup(src string) (io.Writer, io.Writer, io.Writer, error) {
+	return nil, nil, nil, errors.New("system logging not implemented")
+}

--- a/logger_syslog.go
+++ b/logger_syslog.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+//go:build unix
 
 /*
 Copyright 2016 Google Inc. All Rights Reserved.

--- a/logger_windows.go
+++ b/logger_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 /*
 Copyright 2016 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Requesting system logging will then fail at runtime.

It's possible that we eventually want to be more lenient: I don't know how this is called in practise today. Callers would need to ignore the error or pass systemLog=false. But at least it allows the binary to build.

Fixes #45 